### PR TITLE
Added prototype scripts for dataset creation

### DIFF
--- a/PROTOTYPE_DATASET_SCRIPTS/PROTO_auto_synth.bat
+++ b/PROTOTYPE_DATASET_SCRIPTS/PROTO_auto_synth.bat
@@ -1,0 +1,20 @@
+rem Nota Bene: Must be run in the OSS-CAD Suite
+rem ONLY EDIT THE PATHS FOR 'src' AND 'dst'
+
+@echo off
+set src="insert path here"
+set src2=%src:"=%
+
+
+set dst="insert path here"
+set dst2=%dst:"=%
+
+
+rem -S = shortcut for 'synth', -o = outfile, '-f verilog' parses this as verilog
+
+rem Some useful debugging prints
+rem for /R %src% %%f in (*.v) do echo "%%f"
+rem for /R %src% %%f in (*.v) do echo "%%~nf.v"
+rem for /R %src% %%f in (*.v) do echo "%dst2%\synth_%%~nf.v"
+
+for /R %src% %%f in (*.v) do yosys -o "%dst2%\synth_%%~nf.v" -S -f verilog "%%f"

--- a/PROTOTYPE_DATASET_SCRIPTS/PROTO_copy_dir_structure.ps1
+++ b/PROTOTYPE_DATASET_SCRIPTS/PROTO_copy_dir_structure.ps1
@@ -1,0 +1,12 @@
+#NOTE: This script copies a file directory structure into a new path
+#   I use relative paths for my Verilog folders here, but you can use w/e
+
+$source='..\unstructured_verilog_files\'
+$dest='..\synth_unstructured_verilog_files\'
+
+robocopy $source $dest /e /xf *.*
+
+$source='..\structured_verilog_files\'
+$dest='..\synth_structured_verilog_files\'
+
+robocopy $source $dest /e /xf *.*

--- a/PROTOTYPE_DATASET_SCRIPTS/PROTO_dataset_parse_v2.py
+++ b/PROTOTYPE_DATASET_SCRIPTS/PROTO_dataset_parse_v2.py
@@ -1,0 +1,127 @@
+import csv
+import sys
+import git #GitPython used to clone repos 
+from glob import glob #Glob used to recursively travel through files to grab the verilog ones only
+import shutil #shutil used to recursively copy all verilog files + delete the cloned github repos 
+from pathlib import Path
+import os
+
+
+# CHANGE THIS TO THE PATH OF YOUR "permissive_all_deduplicated_repos.csv" file
+REPO_CSV_PATH = r"SET PATH HERE"
+
+# CHANGE THIS TO THE PATH OF YOUR "filtered_near_deduplicated_file_index.csv" file
+DEDUP_CSV_PATH = r"SET PATH HERE"
+
+#THE NUMBER OF REPOS CLONED
+#   SET TO 0 TO SKIP
+REPO_PARSE_COUNT = 5
+
+#Opens the "permissive_all_deduplicated_repos.csv" file to download all repos inside
+def clone_verilog_repos(in_path):
+    with open(in_path, encoding='utf8') as inf:
+        reader = csv.reader(inf)
+        counter = 0 # Temp counter for testing 
+
+        next(inf) #Skip first line of CSV
+        for line in reader:
+            counter += 1 #Temp
+            
+            #Grabs all metadata about the repos
+            #   NOT ALL INFO IS GRABBED/USED ATM
+            repo_url = line[1]
+            repo_date = line[2]
+            repo_desc = line[3]
+            fork_count = line[4]
+            repo_full_name = line[5]
+            repo_lan = line[6]
+            repo_name = line[8]
+            repo_size = line[9]
+
+            #Skip arbitrarily large repository
+            if (int(repo_size) > 50000): 
+                continue
+
+            #Clones the repository to a temporary location
+            curr_path = '../temp_repos/data/full_repos/permissive/' + repo_name
+            #repo = git.Repo.clone_from(repo_url, curr_path, branch='master')
+            try:
+                repo = git.Repo.clone_from(repo_url, curr_path)
+            except:
+                print("issue with repo: " + repo_name)
+
+            #Grabs only the verilog files, then deletes the repository folder
+            isolate_verilog_files(repo_name)
+            isolate_verilog_files_wfstructure(repo_name)
+
+            #WINDOWS ISSUE: Read-only files can't be deleted with shutil.rmtree
+            #   This has some issues with the github files here
+            #   I haven't been able to fix this so I just use a powershell script to run the python script + delete the folders lol
+            #   If someone else gets this to work that would be great
+            '''
+            full_perms = 0o777
+            for filename in glob(curr_path + "/**", recursive=True):
+                print(filename)
+                os.chmod(filename, full_perms)
+            shutil.rmtree(curr_path)
+            '''
+            
+            #TEMP, only tries X repos right now
+            if (counter == REPO_PARSE_COUNT): 
+                break  
+        
+        inf.close() 
+
+
+#Deletes every non-verilog file
+#   Does NOT preserve repo file structure
+def isolate_verilog_files(repo_name):
+    #Pattern matching all folders inside the given repository
+    verilog_search_path = '../temp_repos/data/full_repos/permissive/' + repo_name + "/**/*.v"
+    
+    out_path = '../unstructured_verilog_files/' + repo_name
+    for filename in glob(verilog_search_path, recursive=True):
+        Path(out_path).mkdir(parents=True, exist_ok=True,mode=0o777) #Maybe change mode?
+        
+        #Removes everything but the filename
+        nopath_fname = os.path.basename(filename)
+        
+        #Copies to the target path
+        outpath_withf = out_path + '/' + nopath_fname
+        shutil.copyfile(filename, outpath_withf)
+
+
+#Deletes every non-verilog file
+#   BUT, also maintains file structure in case it's useful
+def isolate_verilog_files_wfstructure(repo_name):
+    #Pattern matching all folders inside the given repository
+    verilog_search_path = '../temp_repos/data/full_repos/permissive/' + repo_name + "/**/*.v"
+    
+    out_path = '../structured_verilog_files/' 
+    for filename in glob(verilog_search_path, recursive=True):
+        #Removes the temp filepath
+        semi_path_fname = filename.replace('../temp_repos/data/full_repos/permissive/', '')
+   
+        outpath_withf = out_path + semi_path_fname
+
+        #Create the path/file, then perform the copy
+        #   Need to make the parent since we have the actual filename now
+        Path(outpath_withf).parent.mkdir(parents=True, exist_ok=True,mode=0o777)  #Maybe change mode?
+        
+        shutil.copyfile(filename, outpath_withf)
+
+
+def main():
+    #if (sys.argv[1]): 
+    if (len(sys.argv) == 2): 
+        in_path = sys.argv[1]
+    else:
+        #Raw strings if you're on windows!
+        in_path = REPO_CSV_PATH
+
+    clone_verilog_repos(in_path)
+
+
+#Executes main automatically
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
These are 3 prototype scripts that are used in the dataset creation for our Verilog translation LLM. They work as follows: 
1. dataset_parse uses the verilog_autocompletion's csv file of github repositories and clones them, then processes the data by removing every non-verilog file 1.a. Ideally this would also delete the cloned repositories, but I have issues doing this on my Windows machine
2. copy_dir_structure copies the file structure from one directory to another. This is a mandatory prerequisite for the third script
3. auth_synth (which is run INSIDE the OSS-CAD-Suite) reads in a verilog file and outputs a synthesized (i.e. elaborated) design into the specified output file With these 3 scripts, we can gather the raw data needed for an initial dataset.  However, the data needs to be processed, and perhaps the scripts made more elaborate as to handle error since there isn't really any error-handling in them.